### PR TITLE
Corrected matrix * vector multiplication in TransformVectorNormalize_default

### DIFF
--- a/source/mupen64plus-video-gles2n64/src/3DMath.cpp
+++ b/source/mupen64plus-video-gles2n64/src/3DMath.cpp
@@ -16,16 +16,19 @@ static void MultMatrix_default( float m0[4][4], float m1[4][4],
 static void TransformVectorNormalize_default(float vec[3], float mtx[4][4])
 {
     float len;
+    float x = vec[0];
+    float y = vec[1];
+    float z = vec[2];
 
-    vec[0] = mtx[0][0] * vec[0]
-           + mtx[1][0] * vec[1]
-           + mtx[2][0] * vec[2];
-    vec[1] = mtx[0][1] * vec[0]
-           + mtx[1][1] * vec[1]
-           + mtx[2][1] * vec[2];
-    vec[2] = mtx[0][2] * vec[0]
-           + mtx[1][2] * vec[1]
-           + mtx[2][2] * vec[2];
+    vec[0] = mtx[0][0] * x
+           + mtx[1][0] * y
+           + mtx[2][0] * z;
+    vec[1] = mtx[0][1] * x
+           + mtx[1][1] * y
+           + mtx[2][1] * z;
+    vec[2] = mtx[0][2] * x
+           + mtx[1][2] * y
+           + mtx[2][2] * z;
     len = vec[0]*vec[0] + vec[1]*vec[1] + vec[2]*vec[2];
     if (len != 0.0)
     {


### PR DESCRIPTION
Previously the vector was being transformed inplace, causing vec[1] and vec[2] to be calculated incorrectly.
The vector is now copied into floats x, y, z before being multiplied by the transformation matrix.
